### PR TITLE
Clean shutdown of open sockets, if die is called

### DIFF
--- a/gtests/net/packetdrill/code.c
+++ b/gtests/net/packetdrill/code.c
@@ -618,6 +618,7 @@ void run_code_event(struct state *state, struct event *event,
 	return;
 
 error_out:
+	state_free(state);
 	die("%s:%d: runtime error in code: %s\n",
 	    state->config->script_path, event->line_number, error);
 	free(error);

--- a/gtests/net/packetdrill/code.c
+++ b/gtests/net/packetdrill/code.c
@@ -573,7 +573,7 @@ void run_code_event(struct state *state, struct event *event,
 {
 	DEBUGP("%d: run code event\n", event->line_number);
 
-	char *error = NULL;
+	char *error = NULL, *script_path = NULL;
 
 	/* Wait for the right time before firing off this event. */
 	wait_for_event(state);
@@ -618,8 +618,10 @@ void run_code_event(struct state *state, struct event *event,
 	return;
 
 error_out:
+	script_path = strdup(state->config->script_path);
 	state_free(state);
 	die("%s:%d: runtime error in code: %s\n",
-	    state->config->script_path, event->line_number, error);
+	    script_path, event->line_number, error);
+	free(script_path);
 	free(error);
 }

--- a/gtests/net/packetdrill/run.c
+++ b/gtests/net/packetdrill/run.c
@@ -401,6 +401,7 @@ static void run_local_packet_event(struct state *state, struct event *event,
 		fprintf(stderr, "%s", error);
 		free(error);
 	} else if (result == STATUS_ERR) {
+		state_free(state);
 		die("%s", error);
 	}
 }
@@ -588,6 +589,7 @@ void run_script(struct config *config, struct script *script)
 		wire_client_next_event(state->wire_client, NULL);
 
 	if (code_execute(state->code, &error)) {
+		state_free(state);
 		die("%s: error executing code: %s\n",
 		    state->config->script_path, error);
 		free(error);

--- a/gtests/net/packetdrill/run.c
+++ b/gtests/net/packetdrill/run.c
@@ -591,9 +591,11 @@ void run_script(struct config *config, struct script *script)
 		wire_client_next_event(state->wire_client, NULL);
 
 	if (code_execute(state->code, &error)) {
+		char *script_path = strdup(state->config->script_path);
 		state_free(state);
 		die("%s: error executing code: %s\n",
-		    state->config->script_path, error);
+		    script_path, error);
+		free(script_path);
 		free(error);
 	}
 

--- a/gtests/net/packetdrill/run.c
+++ b/gtests/net/packetdrill/run.c
@@ -541,8 +541,10 @@ void run_script(struct config *config, struct script *script)
 		wire_client_send_client_starting(state->wire_client);
 
 	while (1) {
-		if (get_next_event(state, &error))
+		if (get_next_event(state, &error)) {
+			state_free(state);
 			die("%s", error);
+		}
 		event = state->event;
 		if (event == NULL)
 			break;

--- a/gtests/net/packetdrill/run_command.c
+++ b/gtests/net/packetdrill/run_command.c
@@ -36,6 +36,7 @@
 void run_command_event(
 	struct state *state, struct event *event, struct command_spec *command)
 {
+	char *script_path = NULL;
 	DEBUGP("%d: command: `%s`\n", event->line_number,
 	       command->command_line);
 
@@ -48,9 +49,11 @@ void run_command_event(
 	return;
 
 error_out:
+	script_path = strdup(state->config->script_path);
 	state_free(state);
 	die("%s:%d: error executing `%s` command: %s\n",
-	    state->config->script_path, event->line_number,
+	    script_path, event->line_number,
 	    command->command_line, error);
+	free(script_path);
 	free(error);
 }

--- a/gtests/net/packetdrill/run_command.c
+++ b/gtests/net/packetdrill/run_command.c
@@ -48,6 +48,7 @@ void run_command_event(
 	return;
 
 error_out:
+	state_free(state);
 	die("%s:%d: error executing `%s` command: %s\n",
 	    state->config->script_path, event->line_number,
 	    command->command_line, error);

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -1958,6 +1958,7 @@ static void invoke_system_call(
 	return;
 
 error_out:
+	state_free(state);
 	die("%s:%d: runtime error in %s call: %s\n",
 	    state->config->script_path, event->line_number,
 	    syscall->name, error);
@@ -2058,6 +2059,7 @@ static void enqueue_system_call(
 	return;
 
 error_out:
+	state_free(state);
 	die("%s:%d: runtime error in %s call: %s\n",
 	    state->config->script_path, event->line_number,
 	    syscall->name, error);

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -1924,7 +1924,7 @@ static void invoke_system_call(
 {
 	DEBUGP("%d: invoke call: %s\n", event->line_number, syscall->name);
 
-	char *error = NULL;
+	char *error = NULL, *script_path = NULL;
 	const char *name = syscall->name;
 	struct expression_list *args = NULL;
 	int i = 0;
@@ -1958,10 +1958,12 @@ static void invoke_system_call(
 	return;
 
 error_out:
+	script_path = strdup(state->config->script_path);
 	state_free(state);
 	die("%s:%d: runtime error in %s call: %s\n",
-	    state->config->script_path, event->line_number,
+	    script_path, event->line_number,
 	    syscall->name, error);
+	free(script_path);
 	free(error);
 }
 
@@ -2008,7 +2010,7 @@ static int yield(void)
 static void enqueue_system_call(
 	struct state *state, struct event *event, struct syscall_spec *syscall)
 {
-	char *error = NULL;
+	char *error = NULL, *script_path = NULL;
 	bool done = false;
 
 	/* Wait if there are back-to-back blocking system calls. */
@@ -2059,10 +2061,12 @@ static void enqueue_system_call(
 	return;
 
 error_out:
+	script_path = strdup(state->config->script_path);
 	state_free(state);
 	die("%s:%d: runtime error in %s call: %s\n",
-	    state->config->script_path, event->line_number,
+	    script_path, event->line_number,
 	    syscall->name, error);
+	free(script_path);
 	free(error);
 }
 


### PR DESCRIPTION
Implemented a clean shutdown, if the method die from logging.c is called. If there are open sockets that need to be closed, the function close_all_sockets now closes them. This prevents bind exceptions, if there are any errors.