### PR TITLE
Modify socketoption sctp_initmsg to use expressions

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -1748,6 +1748,62 @@ static int check_sctp_rtoinfo(struct sctp_rtoinfo_expr *expr,
 }
 #endif
 
+#ifdef SCTP_INITMSG
+static int check_sctp_initmsg(struct sctp_initmsg_expr *expr,
+                              struct sctp_initmsg *sctp_initmsg, char **error)
+{
+	if (expr->sinit_num_ostreams->type != EXPR_ELLIPSIS) {
+		u16 sinit_num_ostreams;
+
+		if (get_u16(expr->sinit_num_ostreams, &sinit_num_ostreams, error)) {
+			return STATUS_ERR;
+		}
+		if (sctp_initmsg->sinit_num_ostreams != sinit_num_ostreams) {
+			asprintf(error, "Bad getsockopt sctp_initmsg.sinit_num_ostreams: expected: %hu actual: %hu",
+				 sinit_num_ostreams, sctp_initmsg->sinit_num_ostreams);
+			return STATUS_ERR;
+		}
+	}
+	if (expr->sinit_max_instreams->type != EXPR_ELLIPSIS) {
+		u16 sinit_max_instreams;
+
+		if (get_u16(expr->sinit_max_instreams, &sinit_max_instreams, error)) {
+			return STATUS_ERR;
+		}
+		if (sctp_initmsg->sinit_max_instreams != sinit_max_instreams) {
+			asprintf(error, "Bad getsockopt sctp_initmsg.sinit_max_instreams: expected: %hu actual: %hu",
+				 sinit_max_instreams, sctp_initmsg->sinit_max_instreams);
+			return STATUS_ERR;
+		}
+	}
+	if (expr->sinit_max_attempts->type != EXPR_ELLIPSIS) {
+		u16 sinit_max_attempts;
+
+		if (get_u16(expr->sinit_max_attempts, &sinit_max_attempts, error)) {
+			return STATUS_ERR;
+		}
+		if (sctp_initmsg->sinit_max_attempts != sinit_max_attempts) {
+			asprintf(error, "Bad getsockopt sctp_initmsg.sinit_max_attempts: expected: %hu actual: %hu",
+				 sinit_max_attempts, sctp_initmsg->sinit_max_attempts);
+			return STATUS_ERR;
+		}
+	}
+	if (expr->sinit_max_init_timeo->type != EXPR_ELLIPSIS) {
+		u16 sinit_max_init_timeo;
+
+		if (get_u16(expr->sinit_max_init_timeo, &sinit_max_init_timeo, error)) {
+			return STATUS_ERR;
+		}
+		if (sctp_initmsg->sinit_max_init_timeo != sinit_max_init_timeo) {
+			asprintf(error, "Bad getsockopt sctp_initmsg.sinit_max_init_timeo: expected: %hu actual: %hu",
+				 sinit_max_init_timeo, sctp_initmsg->sinit_max_init_timeo);
+			return STATUS_ERR;
+		}
+	}
+	return STATUS_OK;
+}
+#endif
+
 #ifdef SCTP_STATUS
 static int check_sctp_paddrinfo(struct sctp_paddrinfo_expr *expr,
 			        struct sctp_paddrinfo *sctp_paddrinfo,
@@ -2093,6 +2149,11 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		live_optlen = (socklen_t)sizeof(struct sctp_rtoinfo);
 		((struct sctp_rtoinfo*)live_optval)->srto_assoc_id = 0;
 #endif
+#ifdef SCTP_INITMSG
+	} else if (val_expression->type == EXPR_SCTP_INITMSG) {
+		live_optval = malloc(sizeof(struct sctp_initmsg));
+		live_optlen = (socklen_t)sizeof(struct sctp_initmsg);
+#endif
 #ifdef SCTP_STATUS
 	} else if (val_expression->type == EXPR_SCTP_STATUS) {
 		live_optval = malloc(sizeof(struct sctp_status));
@@ -2173,6 +2234,13 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 			return STATUS_ERR;
 		}
 #endif
+#ifdef SCTP_INITMSG
+	} else if (val_expression->type == EXPR_SCTP_INITMSG) {
+		if (check_sctp_initmsg(val_expression->value.sctp_initmsg, live_optval, error)) {
+			free(live_optval);
+			return STATUS_ERR;
+		}
+#endif
 #ifdef SCTP_STATUS
 	} else if (val_expression->type == EXPR_SCTP_STATUS) {
 		if (check_sctp_status(val_expression->value.sctp_status, live_optval, error)) {
@@ -2221,6 +2289,9 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 	struct expression *val_expression;
 	struct linger linger;
 	struct sctp_rtoinfo rtoinfo;
+#if defined(SCTP_INITMSG)
+	struct sctp_initmsg initmsg;
+#endif
 #if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 	struct sctp_assoc_value assoc_value;
 #endif
@@ -2286,7 +2357,23 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 #endif
 #ifdef SCTP_INITMSG
 	case EXPR_SCTP_INITMSG:
-		optval = &val_expression->value.sctp_initmsg;
+		if (get_u16(val_expression->value.sctp_initmsg->sinit_num_ostreams,
+			    &initmsg.sinit_num_ostreams, error)) {
+		return STATUS_ERR;
+		}
+		if (get_u16(val_expression->value.sctp_initmsg->sinit_max_instreams,
+			    &initmsg.sinit_max_instreams, error)) {
+			return STATUS_ERR;
+		}
+		if (get_u16(val_expression->value.sctp_initmsg->sinit_max_attempts,
+			    &initmsg.sinit_max_attempts, error)) {
+			return STATUS_ERR;
+		}
+		if (get_u16(val_expression->value.sctp_initmsg->sinit_max_init_timeo,
+			    &initmsg.sinit_max_init_timeo, error)) {
+			return STATUS_ERR;
+		}
+		optval = &initmsg;
 		break;
 #endif
 #if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)

--- a/gtests/net/packetdrill/script.h
+++ b/gtests/net/packetdrill/script.h
@@ -89,7 +89,7 @@ struct expression {
 		struct sctp_rtoinfo_expr *sctp_rtoinfo;
 #endif
 #ifdef SCTP_INITMSG
-		struct sctp_initmsg sctp_initmsg;
+		struct sctp_initmsg_expr *sctp_initmsg;
 #endif
 #if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 		struct sctp_assoc_value_expr *sctp_assoc_value;
@@ -159,6 +159,17 @@ struct sctp_rtoinfo_expr {
 	struct expression *srto_initial;
 	struct expression *srto_max;
 	struct expression *srto_min;
+};
+#endif
+
+
+#ifdef SCTP_INITMSG
+/* Parse tree for a sctp_initmsg struct in a [gs]etsockopt syscall. */
+struct sctp_initmsg_expr {
+	struct expression *sinit_num_ostreams;
+	struct expression *sinit_max_instreams;
+	struct expression *sinit_max_attempts;
+	struct expression *sinit_max_init_timeo;
 };
 #endif
 

--- a/gtests/net/packetdrill/tests/bsd/sctp/sctp_get_socket_options.pkt
+++ b/gtests/net/packetdrill/tests/bsd/sctp/sctp_get_socket_options.pkt
@@ -43,22 +43,22 @@ sstat_primary={ spinfo_state=SCTP_ACTIVE, spinfo_cwnd=4464, spinfo_srtt=..., spi
 
 
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=300, spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=SPP_DSCP|SPP_HB_ENABLE, spp_ipv6_flowlabel=0, spp_dscp=0}, 152) = 0
+spp_hbinterval=300, spp_pathmaxrxt=8, spp_pathmtu=1468, spp_flags=SPP_DSCP|SPP_HB_ENABLE, spp_ipv6_flowlabel=0, spp_dscp=0}, 152) = 0
 
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=300, spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=SPP_DSCP|SPP_HB_ENABLE|SPP_PMTUD_ENABLE, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
+spp_hbinterval=300, spp_pathmaxrxt=8, spp_pathmtu=1468, spp_flags=SPP_DSCP|SPP_HB_ENABLE|SPP_PMTUD_ENABLE, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
 
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=..., spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=..., spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
+spp_hbinterval=..., spp_pathmaxrxt=..., spp_pathmtu=1468, spp_flags=..., spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
 
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=300, spp_pathmtu=..., spp_pathmaxrxt=..., spp_flags=521, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
+spp_hbinterval=300, spp_pathmaxrxt=..., spp_pathmtu=..., spp_flags=521, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
 
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=300, spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=521, spp_ipv6_flowlabel=..., spp_dscp=0}, [152]) = 0
+spp_hbinterval=300, spp_pathmaxrxt=..., spp_pathmtu=1468, spp_flags=521, spp_ipv6_flowlabel=..., spp_dscp=0}, [152]) = 0
 
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(8080), sin_addr=inet_addr("192.0.2.1")},
-spp_hbinterval=300, spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=521, spp_ipv6_flowlabel=0, spp_dscp=...}, [152]) = 0
+spp_hbinterval=300, spp_pathmaxrxt=..., spp_pathmtu=1468, spp_flags=521, spp_ipv6_flowlabel=0, spp_dscp=...}, [152]) = 0
 
 +0 setsockopt(3, SOL_SOCKET, SO_LINGER, {onoff=1, linger=30}, 8) = 0
 +0 getsockopt(3, SOL_SOCKET, SO_LINGER, {onoff=128, linger=30}, [8]) = 0
@@ -72,4 +72,10 @@ spp_hbinterval=300, spp_pathmtu=1468, spp_pathmaxrxt=..., spp_flags=521, spp_ipv
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_RTOINFO, {srto_initial=100, srto_max=..., srto_min=50}, [16]) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_RTOINFO, {srto_initial=100, srto_max=200, srto_min=...}, [16]) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_MAXSEG, {assoc_value=1452}, [8]) = 0
+
++0 setsockopt(3, IPPROTO_SCTP, SCTP_INITMSG, {sinit_num_ostreams=2, sinit_max_instreams=2, sinit_max_attempts=2, sinit_max_init_timeo=30}, 8) = 0
++0 getsockopt(3, IPPROTO_SCTP, SCTP_INITMSG, {sinit_num_ostreams=2, sinit_max_instreams=2, sinit_max_attempts=2, sinit_max_init_timeo=30}, [8]) = 0
++0 getsockopt(3, IPPROTO_SCTP, SCTP_INITMSG, {sinit_num_ostreams=..., sinit_max_instreams=2, sinit_max_attempts=2, sinit_max_init_timeo=30}, [8]) = 0
++0 getsockopt(3, IPPROTO_SCTP, SCTP_INITMSG, {sinit_num_ostreams=2, sinit_max_instreams=..., sinit_max_attempts=2, sinit_max_init_timeo=30}, [8]) = 0
++0 getsockopt(3, IPPROTO_SCTP, SCTP_INITMSG, {sinit_num_ostreams=2, sinit_max_instreams=2, sinit_max_attempts=..., sinit_max_init_timeo=30}, [8]) = 0
 +0 close(3) = 0


### PR DESCRIPTION
Modify the files only to change expressiontype from struct sctp_initmsg to struct sctp_initmsg_expr to store all informations to do and check the parameter for the socketoption