### PR TITLE
Refactoring socketoptions

### DIFF
--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -2556,15 +2556,11 @@ srto_min
 
 sctp_rtoinfo
 : '{' srto_initial ',' srto_max ',' srto_min '}' {
-#ifdef SCTP_RTOINFO
 	$$ = new_expression(EXPR_SCTP_RTOINFO);
 	$$->value.sctp_rtoinfo = calloc(1, sizeof(struct sctp_rtoinfo_expr));
 	$$->value.sctp_rtoinfo->srto_initial = $2;
 	$$->value.sctp_rtoinfo->srto_max = $4;
 	$$->value.sctp_rtoinfo->srto_min = $6;
-#else
-	$$ = NULL;
-#endif
 }
 ;
 
@@ -2665,14 +2661,10 @@ sack_freq
 
 sctp_sackinfo
 : '{' sack_delay ',' sack_freq '}' {
-#ifdef SCTP_DELAYED_SACK
 	$$ = new_expression(EXPR_SCTP_SACKINFO);
 	$$->value.sctp_sack_info = calloc(1, sizeof(struct sctp_sack_info_expr));
 	$$->value.sctp_sack_info->sack_delay = $2;
 	$$->value.sctp_sack_info->sack_freq = $4;	
-#else
-	$$ = NULL;
-#endif
 }
 ;
 
@@ -2958,7 +2950,6 @@ sasoc_cookie_life
 
 sctp_assocparams
 : '{' sasoc_asocmaxrxt ',' sasoc_number_peer_destinations ',' sasoc_peer_rwnd ',' sasoc_local_rwnd ',' sasoc_cookie_life '}' {
-#ifdef SCTP_ASSOCINFO
 	$$ = new_expression(EXPR_SCTP_ASSOCPARAMS);
         $$->value.sctp_assocparams = calloc(1, sizeof(struct sctp_assocparams_expr));
         $$->value.sctp_assocparams->sasoc_asocmaxrxt = $2;
@@ -2966,9 +2957,6 @@ sctp_assocparams
         $$->value.sctp_assocparams->sasoc_peer_rwnd = $6;
         $$->value.sctp_assocparams->sasoc_local_rwnd = $8;
         $$->value.sctp_assocparams->sasoc_cookie_life = $10;
-#elif
-	$$ = NULL;
-#endif
 }
 ;
 
@@ -2997,29 +2985,21 @@ se_on
 
 sctp_event
 : '{' se_type ',' se_on '}' {
-#ifdef SCTP_EVENT
 	$$ = new_expression(EXPR_SCTP_EVENT);
 	$$->value.sctp_event = calloc(1, sizeof(struct sctp_event_expr));
 	$$->value.sctp_event->se_type = $2;
 	$$->value.sctp_event->se_on = $4;
-#elif
-	$$ = NULL;
-#endif
 }
 ;
 
 sctp_setadaptation
 : '{' SSB_ADAPTATION_IND '=' INTEGER '}' {
-#ifdef SCTP_ADAPTATION_LAYER
 	$$ = new_expression(EXPR_SCTP_SETADAPTATION);
 	$$->value.sctp_setadaptation = calloc(1, sizeof(struct sctp_setadaptation));
 	if (!is_valid_u32($4)) {
 		semantic_error("ssb_adaptation_ind out of range");
 	}
 	$$->value.sctp_setadaptation->ssb_adaptation_ind = new_integer_expression($4, "%u");
-#elif
-	$$ = NULL;
-#endif
 }
 ;
 

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -2202,9 +2202,8 @@ static int check_sctp_assocparams(struct sctp_assocparams_expr *expr,
 			return STATUS_ERR;
 		}
 		if (sctp_assocparams->sasoc_number_peer_destinations != sasoc_number_peer_destinations) {
-			asprintf(error, "Bad getsockopt sctp_assocparams.sasoc_number_peer_destinations: 
-				 expected: %hu actual: %hu", sasoc_number_peer_destinations,
-				 sctp_assocparams->sasoc_number_peer_destinations);
+			asprintf(error, "Bad getsockopt sctp_assocparams.sasoc_number_peer_destinations: expected: %hu actual: %hu",
+					 sasoc_number_peer_destinations, sctp_assocparams->sasoc_number_peer_destinations);
 			return STATUS_ERR;
 		}
 	}
@@ -2506,7 +2505,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		live_optlen = sizeof(struct sctp_setadaptation);
 		break;
 #endif
-	case EXPR_INTEGER:
+	case EXPR_LIST:
 		s32_bracketed_arg(args, 3, &script_optval, error);
 		live_optval = malloc(sizeof(int));
 		live_optlen = (socklen_t)sizeof(int);
@@ -2597,7 +2596,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		result = check_sctp_setadaptation(val_expression->value.sctp_setadaptation, live_optval, error);
 		break;
 #endif
-	case EXPR_INTEGER:
+	case EXPR_LIST:
 		if (*(int*)live_optval != script_optval) {
 			asprintf(error, "Bad getsockopt optval: expected: %d actual: %d",
 				(int)script_optval, *(int*)live_optval);

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -2024,7 +2024,8 @@ static int check_sctp_status(struct sctp_status_expr *expr,
 		}
 	}
 	if (expr->sstat_primary->type != EXPR_ELLIPSIS) {
-		if (check_sctp_paddrinfo(expr->sstat_primary->value.sctp_paddrinfo,  &sctp_status->sstat_primary, error)) {
+		if (check_sctp_paddrinfo(expr->sstat_primary->value.sctp_paddrinfo,
+					 &sctp_status->sstat_primary, error)) {
 			return STATUS_ERR;
 		}
 	}
@@ -2201,8 +2202,9 @@ static int check_sctp_assocparams(struct sctp_assocparams_expr *expr,
 			return STATUS_ERR;
 		}
 		if (sctp_assocparams->sasoc_number_peer_destinations != sasoc_number_peer_destinations) {
-			asprintf(error, "Bad getsockopt sctp_assocparams.sasoc_number_peer_destinations: expected: %hu actual: %hu",
-				 sasoc_number_peer_destinations, sctp_assocparams->sasoc_number_peer_destinations);
+			asprintf(error, "Bad getsockopt sctp_assocparams.sasoc_number_peer_destinations: 
+				 expected: %hu actual: %hu", sasoc_number_peer_destinations,
+				 sctp_assocparams->sasoc_number_peer_destinations);
 			return STATUS_ERR;
 		}
 	}
@@ -2435,7 +2437,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 					&(live_paddrinfo->spinfo_address), live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spinfo_address");
 			free(live_paddrinfo);
-			return STATUS_ERR;			
+			return STATUS_ERR;
 		}
 		live_optval = live_paddrinfo;
 		break;
@@ -2451,7 +2453,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 					live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spp_address");
 			free(live_params);
-			return STATUS_ERR;			
+			return STATUS_ERR;
 		}
 		live_params->spp_assoc_id = 0;
 		live_optval = live_params;
@@ -2482,7 +2484,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 	case EXPR_SCTP_EVENT:
 		live_optval = malloc(sizeof(struct sctp_event));
 		live_optlen = sizeof(struct sctp_event);
-		((struct sctp_event *)live_optval)->se_assoc_id = 0; 
+		((struct sctp_event *)live_optval)->se_assoc_id = 0;
 		if (get_u16(val_expression->value.sctp_event->se_type,
 			    &((struct sctp_event *)live_optval)->se_type,
 			    error)) {
@@ -2495,7 +2497,7 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 	case EXPR_SCTP_SNDINFO:
 		live_optval = malloc(sizeof(struct sctp_sndinfo));
 		live_optlen = sizeof(struct sctp_sndinfo);
-		((struct sctp_sndinfo *)live_optval)->snd_assoc_id = 0; 
+		((struct sctp_sndinfo *)live_optval)->snd_assoc_id = 0;
 		break;
 #endif
 #ifdef SCTP_ADAPTATION_LAYER
@@ -2790,7 +2792,7 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 		if (get_u32(val_expression->value.sctp_sack_info->sack_freq,
 		            &sack_info.sack_freq, error)) {
 			return STATUS_ERR;
-		}		
+		}
 		optval = &sack_info;
 		break;
 #endif
@@ -2803,12 +2805,12 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 #ifdef SCTP_GET_PEER_ADDR_INFO
 	case EXPR_SCTP_PADDRINFO:
 		paddrinfo.spinfo_assoc_id = 0;
-		if (get_sockstorage_arg(val_expression->value.sctp_paddrinfo->spinfo_address, 
+		if (get_sockstorage_arg(val_expression->value.sctp_paddrinfo->spinfo_address,
 					&paddrinfo.spinfo_address, live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spp_address");
-			return STATUS_ERR;			
+			return STATUS_ERR;
 		}
-		optval = &paddrinfo;			
+		optval = &paddrinfo;
 		break;
 #endif
 #ifdef SCTP_EVENT

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -275,17 +275,17 @@ static int get_s16(struct expression *expression,
 static int get_u8(struct expression *expression,
 		  u8 *value, char **error)
 {
-        if (check_type(expression, EXPR_INTEGER, error))
-                return STATUS_ERR;
-        if ((expression->value.num > UINT8_MAX) ||
-                (expression->value.num < 0)) {
-                asprintf(error,
-                        "Value out of range for 8-bit unsigned integer: %lld",
-                        expression->value.num);
-                return STATUS_ERR;
-        }
-        *value = expression->value.num;
-        return STATUS_OK;
+	if (check_type(expression, EXPR_INTEGER, error))
+		return STATUS_ERR;
+	if ((expression->value.num > UINT8_MAX) ||
+		(expression->value.num < 0)) {
+		asprintf(error,
+			 "Value out of range for 8-bit unsigned integer: %lld",
+			 expression->value.num);
+		return STATUS_ERR;
+	}
+	*value = expression->value.num;
+	return STATUS_OK;
 }
 #endif
 
@@ -297,17 +297,17 @@ static int get_u8(struct expression *expression,
 static int get_s8(struct expression *expression,
 		  s8 *value, char **error)
 {
-        if (check_type(expression, EXPR_INTEGER, error))
-                return STATUS_ERR;
-        if ((expression->value.num > INT8_MAX) ||
-                (expression->value.num < INT8_MIN)) {
-                asprintf(error,
-                        "Value out of range for 8-bit integer: %lld",
-                        expression->value.num);
-                return STATUS_ERR;
-        }
-        *value = expression->value.num;
-        return STATUS_OK;
+	if (check_type(expression, EXPR_INTEGER, error))
+		return STATUS_ERR;
+	if ((expression->value.num > INT8_MAX) ||
+		(expression->value.num < INT8_MIN)) {
+		asprintf(error,
+			 "Value out of range for 8-bit integer: %lld",
+			 expression->value.num);
+		return STATUS_ERR;
+	}
+	*value = expression->value.num;
+	return STATUS_OK;
 }
 #endif
 
@@ -1778,7 +1778,7 @@ static int check_sctp_rtoinfo(struct sctp_rtoinfo_expr *expr,
 
 #ifdef SCTP_INITMSG
 static int check_sctp_initmsg(struct sctp_initmsg_expr *expr,
-                              struct sctp_initmsg *sctp_initmsg, char **error)
+			      struct sctp_initmsg *sctp_initmsg, char **error)
 {
 	if (expr->sinit_num_ostreams->type != EXPR_ELLIPSIS) {
 		u16 sinit_num_ostreams;
@@ -1867,8 +1867,8 @@ static int check_sctp_sack_info(struct sctp_sack_info_expr *expr,
 
 #if defined(SCTP_GET_PEER_ADDR_INFO) || defined(SCTP_STATUS)
 static int check_sctp_paddrinfo(struct sctp_paddrinfo_expr *expr,
-			        struct sctp_paddrinfo *sctp_paddrinfo,
-			        char **error)
+				struct sctp_paddrinfo *sctp_paddrinfo,
+				char **error)
 {
 	if (expr->spinfo_state->type != EXPR_ELLIPSIS) {
 		s32 spinfo_state;
@@ -2431,7 +2431,8 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		live_optlen = (socklen_t)sizeof(struct sctp_paddrinfo);
 		memset(live_paddrinfo, 0, sizeof(struct sctp_paddrinfo));
 		live_paddrinfo->spinfo_assoc_id = 0;
-		if (get_sockstorage_arg(expr_paddrinfo->spinfo_address, &(live_paddrinfo->spinfo_address), live_fd, error)){
+		if (get_sockstorage_arg(expr_paddrinfo->spinfo_address,
+					&(live_paddrinfo->spinfo_address), live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spinfo_address");
 			free(live_paddrinfo);
 			return STATUS_ERR;			
@@ -2446,7 +2447,8 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		struct sctp_paddrparams *live_params = malloc(sizeof(struct sctp_paddrparams));
 		memset(live_params, 0, sizeof(struct sctp_paddrparams));
 		live_optlen = sizeof(struct sctp_paddrparams);
-		if (get_sockstorage_arg(expr_params->spp_address, &live_params->spp_address, live_fd, error)){
+		if (get_sockstorage_arg(expr_params->spp_address, &live_params->spp_address,
+					live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spp_address");
 			free(live_params);
 			return STATUS_ERR;			
@@ -2469,8 +2471,8 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		live_optlen = (socklen_t)sizeof(struct sctp_stream_value);
 		((struct sctp_stream_value *) live_optval)->assoc_id = 0;
 		if (get_u16(val_expression->value.sctp_stream_value->stream_id,
-		            &((struct sctp_stream_value *)live_optval)->stream_id,
-		            error)) {
+			    &((struct sctp_stream_value *)live_optval)->stream_id,
+			    error)) {
 			free(live_optval);
 			return STATUS_ERR;
 		}
@@ -2482,11 +2484,11 @@ static int syscall_getsockopt(struct state *state, struct syscall_spec *syscall,
 		live_optlen = sizeof(struct sctp_event);
 		((struct sctp_event *)live_optval)->se_assoc_id = 0; 
 		if (get_u16(val_expression->value.sctp_event->se_type,
-		            &((struct sctp_event *)live_optval)->se_type,
+			    &((struct sctp_event *)live_optval)->se_type,
 			    error)) {
 			free(live_optval);
 			return STATUS_ERR;
-               	}
+		}
 		break;
 #endif
 #ifdef SCTP_DEFAULT_SNDINFO
@@ -2802,7 +2804,7 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 	case EXPR_SCTP_PADDRINFO:
 		paddrinfo.spinfo_assoc_id = 0;
 		if (get_sockstorage_arg(val_expression->value.sctp_paddrinfo->spinfo_address, 
-					&paddrinfo.spinfo_address, live_fd, error)){
+					&paddrinfo.spinfo_address, live_fd, error)) {
 			asprintf(error, "Bad getsockopt, bad get input for spp_address");
 			return STATUS_ERR;			
 		}
@@ -2857,23 +2859,8 @@ static int syscall_setsockopt(struct state *state, struct syscall_spec *syscall,
 #ifdef SCTP_PEER_ADDR_PARAMS
 	case EXPR_SCTP_PEER_ADDR_PARAMS:
 		paddrparams.spp_assoc_id = 0;
-		if (val_expression->value.sctp_paddrparams->spp_address->type == EXPR_SOCKET_ADDRESS_IPV4) {
-			memcpy(&paddrparams.spp_address,
-			       val_expression->value.sctp_paddrparams->spp_address->value.socket_address_ipv4,
-			       sizeof(struct sockaddr_in));
-		} else if (val_expression->value.sctp_paddrparams->spp_address->type == EXPR_SOCKET_ADDRESS_IPV6) {
-			memcpy(&paddrparams.spp_address,
-			       val_expression->value.sctp_paddrparams->spp_address->value.socket_address_ipv6,
-			       sizeof(struct sockaddr_in6));
-		} else if (val_expression->value.sctp_paddrparams->spp_address->type == EXPR_ELLIPSIS) {
-			socklen_t len_addr = sizeof(struct sockaddr_storage);
-			if (getpeername(live_fd,
-			                (struct sockaddr*)&paddrparams.spp_address,
-			                &len_addr)) {
-				asprintf(error, "Bad setsockopt, bad get primary peer address");
-				return STATUS_ERR;
-			}
-		} else {
+		if (get_sockstorage_arg(val_expression->value.sctp_paddrparams->spp_address, 
+				        &paddrparams.spp_address, live_fd, error)) {
 			asprintf(error, "Bad setsockopt, bad input for spp_address for socketoption SCTP_PADDRPARAMS");
 			return STATUS_ERR;
 		}

--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -1865,7 +1865,7 @@ static int check_sctp_sack_info(struct sctp_sack_info_expr *expr,
 }
 #endif
 
-#ifdef SCTP_STATUS
+#if defined(SCTP_GET_PEER_ADDR_INFO) || defined(SCTP_STATUS)
 static int check_sctp_paddrinfo(struct sctp_paddrinfo_expr *expr,
 			        struct sctp_paddrinfo *sctp_paddrinfo,
 			        char **error)
@@ -1932,7 +1932,9 @@ static int check_sctp_paddrinfo(struct sctp_paddrinfo_expr *expr,
 	}
 	return STATUS_OK;
 }
+#endif
 
+#ifdef SCTP_STATUS
 static int check_sctp_status(struct sctp_status_expr *expr,
 			     struct sctp_status *sctp_status,
 			     char **error)

--- a/gtests/net/packetdrill/script.c
+++ b/gtests/net/packetdrill/script.c
@@ -65,38 +65,17 @@ struct expression_type_entry expression_type_table[] = {
 	{ EXPR_IOVEC,                "iovec" },
 	{ EXPR_MSGHDR,               "msghdr" },
 	{ EXPR_POLLFD,               "pollfd" },
-#ifdef SCTP_RTOINFO
 	{ EXPR_SCTP_RTOINFO,         "sctp_rtoinfo"},
-#endif
-#ifdef SCTP_INITMSG
 	{ EXPR_SCTP_INITMSG,         "sctp_initmsg"},
-#endif
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 	{ EXPR_SCTP_ASSOC_VALUE,     "sctp_assoc_value"},
-#endif
-#ifdef SCTP_DELAYED_SACK
 	{ EXPR_SCTP_SACKINFO,        "sctp_sackinfo"},
-#endif
-#ifdef SCTP_STATUS
 	{ EXPR_SCTP_STATUS,          "sctp_status"},
 	{ EXPR_SCTP_PADDRINFO,	     "sctp_paddrinfo"},
-#endif
-#ifdef SCTP_PEER_ADDR_PARAMS
-	{ EXPR_SCTP_PEER_ADDR_PARAMS,	"sctp_peer_addr_params"},
-#endif
-#ifdef SCTP_SS_VALUE
+	{ EXPR_SCTP_PEER_ADDR_PARAMS,"sctp_peer_addr_params"},
 	{ EXPR_SCTP_STREAM_VALUE,    "sctp_stream_value"},
-#endif
-#ifdef SCTP_ASSOCINFO
 	{ EXPR_SCTP_ASSOCPARAMS,     "sctp_assocparams"},
-#endif
-#ifdef SCTP_EVENT
 	{ EXPR_SCTP_EVENT,	     "sctp_event"      },
-#endif
-#ifdef SCTP_ADAPTATION_LAYER
 	{ EXPR_SCTP_SETADAPTATION,   "sctp_setadaptation"},
-#endif
-
 	{ NUM_EXPR_TYPES,            NULL}
 };
 
@@ -308,21 +287,16 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.linger->l_onoff);
 		free_expression(expression->value.linger->l_linger);
 		break;
-#ifdef SCTP_RTOINFO
 	case EXPR_SCTP_RTOINFO:
 		assert(expression->value.sctp_rtoinfo);
 		free_expression(expression->value.sctp_rtoinfo->srto_initial);
 		free_expression(expression->value.sctp_rtoinfo->srto_max);
 		free_expression(expression->value.sctp_rtoinfo->srto_min);
 		break;
-#endif
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 	case EXPR_SCTP_ASSOC_VALUE:
 		assert(expression->value.sctp_assoc_value);
 		free_expression(expression->value.sctp_assoc_value->assoc_value);
 		break;
-#endif
-#ifdef SCTP_INITMSG
 	case EXPR_SCTP_INITMSG:
 		assert(expression->value.sctp_initmsg);
 		free_expression(expression->value.sctp_initmsg->sinit_num_ostreams);
@@ -330,15 +304,11 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.sctp_initmsg->sinit_max_attempts);
 		free_expression(expression->value.sctp_initmsg->sinit_max_init_timeo);
 		break;
-#endif
-#ifdef SCTP_DELAYED_SACK
 	case EXPR_SCTP_SACKINFO:
 		assert(expression->value.sctp_sack_info);
 		free_expression(expression->value.sctp_sack_info->sack_delay);
 		free_expression(expression->value.sctp_sack_info->sack_freq);		
 		break;
-#endif
-#ifdef SCTP_STATUS
 	case EXPR_SCTP_PADDRINFO:
 		assert(expression->value.sctp_paddrinfo);
 		free_expression(expression->value.sctp_paddrinfo->spinfo_address);
@@ -359,8 +329,6 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.sctp_status->sstat_fragmentation_point);
 		free_expression(expression->value.sctp_status->sstat_primary);
 		break;
-#endif
-#ifdef SCTP_PEER_ADDR_PARAMS
 	case EXPR_SCTP_PEER_ADDR_PARAMS:
 		assert(expression->value.sctp_paddrparams);
 		free_expression(expression->value.sctp_paddrparams->spp_address);
@@ -371,15 +339,11 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.sctp_paddrparams->spp_ipv6_flowlabel);
 		free_expression(expression->value.sctp_paddrparams->spp_dscp);
 		break;
-#endif
-#ifdef SCTP_SS_VALUE
 	case EXPR_SCTP_STREAM_VALUE:
 		assert(expression->value.sctp_stream_value);
 		free_expression(expression->value.sctp_stream_value->stream_id);
 		free_expression(expression->value.sctp_stream_value->stream_value);
 		break;
-#endif
-#ifdef SCTP_ASSOCINFO
 	case EXPR_SCTP_ASSOCPARAMS:
 		free_expression(expression->value.sctp_assocparams->sasoc_asocmaxrxt);
 		free_expression(expression->value.sctp_assocparams->sasoc_number_peer_destinations);
@@ -387,18 +351,13 @@ void free_expression(struct expression *expression)
 		free_expression(expression->value.sctp_assocparams->sasoc_local_rwnd);
 		free_expression(expression->value.sctp_assocparams->sasoc_cookie_life);
 		break;
-#endif
-#ifdef SCTP_EVENT
 	case EXPR_SCTP_EVENT:
 		free_expression(expression->value.sctp_event->se_type);
 		free_expression(expression->value.sctp_event->se_on);
 		break;
-#endif
-#ifdef SCTP_ADAPTATION_LAYER
 	case EXPR_SCTP_SETADAPTATION:
 		free_expression(expression->value.sctp_setadaptation->ssb_adaptation_ind);
 		break;
-#endif
 	case EXPR_WORD:
 		assert(expression->value.string);
 		free(expression->value.string);
@@ -584,7 +543,6 @@ static int evaluate_pollfd_expression(struct expression *in,
 	return STATUS_OK;
 }
 
-#ifdef SCTP_RTOINFO
 static int evaluate_sctp_rtoinfo_expression(struct expression *in,
 					    struct expression *out,
 					    char **error)
@@ -616,9 +574,7 @@ static int evaluate_sctp_rtoinfo_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_INITMSG
 static int evaluate_sctp_initmsg_expression(struct expression *in,
 					    struct expression *out,
 					    char **error)
@@ -653,9 +609,7 @@ static int evaluate_sctp_initmsg_expression(struct expression *in,
 		return STATUS_ERR;
 	return STATUS_OK;
 }
-#endif
 
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 static int evaluate_sctp_assoc_value_expression(struct expression *in,
 						struct expression *out,
 						char **error)
@@ -679,9 +633,7 @@ static int evaluate_sctp_assoc_value_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_DELAYED_SACK
 static int evaluate_sctp_sack_info_expression(struct expression *in,
 					    struct expression *out,
 					    char **error)
@@ -709,9 +661,7 @@ static int evaluate_sctp_sack_info_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_STATUS
 static int evaluate_sctp_paddrinfo_expression(struct expression *in,
 					      struct expression *out,
 					      char **error)
@@ -806,9 +756,7 @@ static int evaluate_sctp_status_expression(struct expression *in,
 		return STATUS_ERR;
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_PEER_ADDR_PARAMS
 static int evaluate_sctp_peer_addr_param_expression(struct expression *in,
 						    struct expression *out,
 						    char **error)
@@ -855,9 +803,7 @@ static int evaluate_sctp_peer_addr_param_expression(struct expression *in,
 		return STATUS_ERR;
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_SS_VALUE
 static int evaluate_sctp_stream_value_expression(struct expression *in,
 						 struct expression *out,
 						 char **error)
@@ -885,9 +831,7 @@ static int evaluate_sctp_stream_value_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_EVENT
 static int evaluate_sctp_event_expression(struct expression *in,
 						 struct expression *out,
 						 char **error)
@@ -915,9 +859,7 @@ static int evaluate_sctp_event_expression(struct expression *in,
 
 	return STATUS_OK; 
 }
-#endif
 
-#ifdef SCTP_ASSOCINFO
 static int evaluate_sctp_accocparams_expression(struct expression *in,
 						struct expression *out,
 						char **error)
@@ -957,9 +899,7 @@ static int evaluate_sctp_accocparams_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
-#ifdef SCTP_ADAPTATION_LAYER
 static int evaluate_sctp_setadaptation_expression(struct expression *in,
 						  struct expression *out,
 						  char **error)
@@ -983,7 +923,6 @@ static int evaluate_sctp_setadaptation_expression(struct expression *in,
 
 	return STATUS_OK;
 }
-#endif
 
 static int evaluate(struct expression *in,
 		    struct expression **out_ptr, char **error)
@@ -1008,59 +947,39 @@ static int evaluate(struct expression *in,
 		memcpy(&out->value.linger, &in->value.linger,
 		       sizeof(in->value.linger));
 		break;
-#ifdef SCTP_RTOINFO
 	case EXPR_SCTP_RTOINFO:
-		evaluate_sctp_rtoinfo_expression(in, out, error);
+		result = evaluate_sctp_rtoinfo_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_ASSOCINFO
 	case EXPR_SCTP_ASSOCPARAMS:
-		evaluate_sctp_accocparams_expression(in, out, error);
+		result = evaluate_sctp_accocparams_expression(in, out, error);
 		break;
-#endif	
-#ifdef SCTP_INITMSG
 	case EXPR_SCTP_INITMSG:
-		evaluate_sctp_initmsg_expression(in, out, error);
+		result = evaluate_sctp_initmsg_expression(in, out, error);
 		break;
-#endif
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 	case EXPR_SCTP_ASSOC_VALUE:
-		evaluate_sctp_assoc_value_expression(in, out, error);
+		result = evaluate_sctp_assoc_value_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_DELAYED_SACK
 	case EXPR_SCTP_SACKINFO:
-		evaluate_sctp_sack_info_expression(in, out, error);	
+		result = evaluate_sctp_sack_info_expression(in, out, error);	
 		break;
-#endif
-#ifdef SCTP_STATUS
 	case EXPR_SCTP_PADDRINFO:
-		evaluate_sctp_paddrinfo_expression(in, out, error);
+		result = evaluate_sctp_paddrinfo_expression(in, out, error);
 		break;
 	case EXPR_SCTP_STATUS:
 		result = evaluate_sctp_status_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_PEER_ADDR_PARAMS
 	case EXPR_SCTP_PEER_ADDR_PARAMS:
 		result = evaluate_sctp_peer_addr_param_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_SS_VALUE
 	case EXPR_SCTP_STREAM_VALUE:
-		evaluate_sctp_stream_value_expression(in, out, error);
+		result = evaluate_sctp_stream_value_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_EVENT
 	case EXPR_SCTP_EVENT:
 		result = evaluate_sctp_event_expression(in, out, error);
 		break;
-#endif
-#ifdef SCTP_ADAPTATION_LAYER
 	case EXPR_SCTP_SETADAPTATION:
 		result = evaluate_sctp_setadaptation_expression(in, out, error);
 		break;
-#endif
 	case EXPR_WORD:
 		out->type = EXPR_INTEGER;
 		if (symbol_to_int(in->value.string,

--- a/gtests/net/packetdrill/script.h
+++ b/gtests/net/packetdrill/script.h
@@ -48,7 +48,7 @@ enum expression_t {
 	EXPR_SCTP_RTOINFO,	  /* struct sctp_rtoinfo for SCTP_RTOINFO */
 	EXPR_SCTP_INITMSG,	  /* struct sctp_initmsg for SCTP_INITMSG */
 	EXPR_SCTP_ASSOC_VALUE,	  /* struct sctp_assoc_value */
-	EXPR_SCTP_SACKINFO,	  /* struct sctp_sack_info_expr for
+	EXPR_SCTP_SACKINFO,	  /* struct sctp_sack_info_expr for */
 	EXPR_SCTP_STATUS,	  /* struct sctp_status for SCTP_STATUS */
 	EXPR_SCTP_PADDRINFO,
 	EXPR_SCTP_STREAM_VALUE,	  /* struct sctp_stream_value for SCTP_SS_VALUE */

--- a/gtests/net/packetdrill/script.h
+++ b/gtests/net/packetdrill/script.h
@@ -45,38 +45,17 @@ enum expression_t {
 	EXPR_IOVEC,		  /* expression tree for an iovec struct */
 	EXPR_MSGHDR,		  /* expression tree for a msghdr struct */
 	EXPR_POLLFD,		  /* expression tree for a pollfd struct */
-#ifdef SCTP_RTOINFO
 	EXPR_SCTP_RTOINFO,	  /* struct sctp_rtoinfo for SCTP_RTOINFO */
-#endif
-#ifdef SCTP_INITMSG
 	EXPR_SCTP_INITMSG,	  /* struct sctp_initmsg for SCTP_INITMSG */
-#endif
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 	EXPR_SCTP_ASSOC_VALUE,	  /* struct sctp_assoc_value */
-#endif
-#ifdef SCTP_DELAYED_SACK
 	EXPR_SCTP_SACKINFO,	  /* struct sctp_sack_info_expr for
-				   * SCTP_DELAYED_SACK */
-#endif
-#ifdef SCTP_STATUS
 	EXPR_SCTP_STATUS,	  /* struct sctp_status for SCTP_STATUS */
 	EXPR_SCTP_PADDRINFO,
-#endif
-#ifdef SCTP_SS_VALUE
 	EXPR_SCTP_STREAM_VALUE,	  /* struct sctp_stream_value for SCTP_SS_VALUE */
-#endif
-#ifdef SCTP_PEER_ADDR_PARAMS
 	EXPR_SCTP_PEER_ADDR_PARAMS,	 /* struct for sctp_paddrparams for SCTP_PEER_ADDR_PARAMS */
-#endif
-#ifdef SCTP_ASSOCINFO
 	EXPR_SCTP_ASSOCPARAMS,    /* struct sctp_assocparams for SCTP_ASSOCINFO */
-#endif
-#ifdef SCTP_EVENT
 	EXPR_SCTP_EVENT,	  /* struct sctp_event to for SCTP_EVENT */
-#endif
-#ifdef SCTP_ADAPTATION_LAYER
 	EXPR_SCTP_SETADAPTATION, /* struct sctp_setadaptation for SCTP_ADATTATION_LAYER */
-#endif
 	NUM_EXPR_TYPES,
 };
 /* Convert an expression type to a human-readable string */
@@ -96,38 +75,17 @@ struct expression {
 		struct iovec_expr *iovec;
 		struct msghdr_expr *msghdr;
 		struct pollfd_expr *pollfd;
-#ifdef SCTP_RTOINFO
 		struct sctp_rtoinfo_expr *sctp_rtoinfo;
-#endif
-#ifdef SCTP_INITMSG
 		struct sctp_initmsg_expr *sctp_initmsg;
-#endif
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 		struct sctp_assoc_value_expr *sctp_assoc_value;
-#endif
-#ifdef SCTP_DELAYED_SACK
 		struct sctp_sack_info_expr *sctp_sack_info;
-#endif
-#ifdef SCTP_STATUS
 		struct sctp_status_expr *sctp_status;
 		struct sctp_paddrinfo_expr *sctp_paddrinfo;
-#endif
-#ifdef SCTP_PEER_ADDR_PARAMS
 		struct sctp_paddrparams_expr *sctp_paddrparams;
-#endif
-#ifdef SCTP_SS_VALUE
 		struct sctp_stream_value_expr *sctp_stream_value;
-#endif
-#ifdef SCTP_ASSOCINFO
 		struct sctp_assocparams_expr *sctp_assocparams;
-#endif
-#ifdef SCTP_EVENT
 		struct sctp_event_expr *sctp_event;
-#endif
-#ifdef SCTP_ADAPTATION_LAYER
 		struct sctp_setadaptation_expr *sctp_setadaptation;
-#endif
-
 	} value;
 	const char *format;	/* the printf format for printing the value */
 };
@@ -175,15 +133,12 @@ struct linger_expr {
 	struct expression *l_linger;
 };
 /* Parse tree for a sctp_rtoinfo struct in a [gs]etsockopt syscall. */
-#ifdef SCTP_RTOINFO
 struct sctp_rtoinfo_expr {
 	struct expression *srto_initial;
 	struct expression *srto_max;
 	struct expression *srto_min;
 };
-#endif
 
-#ifdef SCTP_INITMSG
 /* Parse tree for a sctp_initmsg struct in a [gs]etsockopt syscall. */
 struct sctp_initmsg_expr {
 	struct expression *sinit_num_ostreams;
@@ -191,32 +146,25 @@ struct sctp_initmsg_expr {
 	struct expression *sinit_max_attempts;
 	struct expression *sinit_max_init_timeo;
 };
-#endif
 
-#if defined(SCTP_MAXSEG) || defined(SCTP_MAX_BURST) || defined(SCTP_INTERLEAVING_SUPPORTED)
 /* Parse tree for a sctp_assoc_value struct in a [gs]etsockopt syscall. */
 struct sctp_assoc_value_expr {
 	struct expression *assoc_value;
 };
-#endif
 
-#ifdef SCTP_SS_VALUE
 /* Parse tree for a sctp_stream_value struct in a [gs]etsockopt syscall. */
 struct sctp_stream_value_expr {
 	struct expression *stream_id;
 	struct expression *stream_value;
 };
-#endif
 
-#ifdef SCTP_DELAYED_SACK
 /* Parse tree for a sctp_sack_info struct in a [gs]etsockopt syscall. */
 struct sctp_sack_info_expr {
 	struct expression *sack_delay;
 	struct expression *sack_freq;
 };
-#endif
+
 /* Parse tree for a sctp_status struct in a [gs]etsockopt syscall. */
-#ifdef SCTP_STATUS
 struct sctp_status_expr {
 	struct expression *sstat_state;
 	struct expression *sstat_rwnd;
@@ -237,7 +185,6 @@ struct sctp_paddrinfo_expr {
 	struct expression *spinfo_rto;
 	struct expression *spinfo_mtu;
 };
-#endif
 
 /* Parse tree for a sctp_paddrparams struct in a [gs]etsockopt syscall. */
 struct sctp_paddrparams_expr {
@@ -250,7 +197,6 @@ struct sctp_paddrparams_expr {
 	struct expression *spp_dscp;
 };
 
-#ifdef SCTP_ASSOCINFO
 /* Parse tree for sctp_assocparams struct in [gs]etsockopt syscall. */
 struct sctp_assocparams_expr {
 	struct expression *sasoc_asocmaxrxt;
@@ -259,22 +205,17 @@ struct sctp_assocparams_expr {
 	struct expression *sasoc_local_rwnd;
 	struct expression *sasoc_cookie_life;
 };
-#endif
 
-#ifdef SCTP_EVENT
 /* Parse tree for sctp_event struct in [gs]etsockopt syscall. */
 struct sctp_event_expr {
 	struct expression *se_type;
 	struct expression *se_on;
 };
-#endif
 
-#ifdef SCTP_ADAPTATION_LAYER
 /* Parse tree for sctp_setadaptation struct in [gs]etsockopt syscall. */
 struct sctp_setadaptation_expr {
 	struct expression *ssb_adaptation_ind;
 };
-#endif
 
 /* The errno-related info from strace to summarize a system call error */
 struct errno_spec {

--- a/gtests/net/packetdrill/symbols_linux.c
+++ b/gtests/net/packetdrill/symbols_linux.c
@@ -107,7 +107,9 @@ struct int_symbol platform_symbols_table[] = {
 	{ SCTP_MAXSEG,                      "SCTP_MAXSEG"                     },
 	{ SCTP_DELAYED_SACK,                "SCTP_DELAYED_SACK"               },
 	{ SCTP_MAX_BURST,                   "SCTP_MAX_BURST"                  },
+#ifdef SCTP_EVENT
 	{ SCTP_EVENT,                       "SCTP_EVENT"                      },
+#endif
 	{ SCTP_PEER_ADDR_PARAMS,            "SCTP_PEER_ADDR_PARAMS"           },
 	{ SCTP_STATUS,                      "SCTP_STATUS"                     },
 	{ SCTP_GET_PEER_ADDR_INFO,          "SCTP_GET_PEER_ADDR_INFO"         },

--- a/gtests/net/packetdrill/tests/bsd/sctp/sctp_get_socket_options.pkt
+++ b/gtests/net/packetdrill/tests/bsd/sctp/sctp_get_socket_options.pkt
@@ -8,7 +8,7 @@
 +0.0 > sctp: COOKIE_ECHO[flgs=0, len=4, val=...]
 +0.1 < sctp: COOKIE_ACK[flgs=0]
 
-//+0.0 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.0 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_STATUS, {sstat_state=..., sstat_rwnd=..., sstat_unackdata=..., sstat_penddata=...,
 sstat_instrms=..., sstat_outstrms=..., sstat_fragmentation_point=..., sstat_primary=...}, 176) = -1


### PR DESCRIPTION
I have made some corrections of codestyle and convert if/else to switch/case in run_systemcall.c. I have removed the ifdef s for all expressions, so the handling for an expression is only at the syscall not in the parser.

Do you have some more points?

I want to correct the files in /contrib for the new sctp_structs in an other commit later