### PR TITLE
Test for behavior when sending a packet with no TCP flag set

### DIFF
--- a/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-no-tcp-flags.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-no-tcp-flags.pkt
@@ -1,0 +1,21 @@
+// Test behavior when a listener gets an incoming packet that has
+// no TCP flags set.
+
+0.000 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+0.000 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+0.000 bind(3, ..., ...) = 0
+0.000 listen(3, 1) = 0
+
+// An incoming TCP segment with no TCP flags set.
+0.100 < - 0:0(0) win 65535 <mss 1460,sackOK,nop,nop,nop,wscale 7>
+// FreeBSD ignores the packet and sends nothing.
+
+// Now make sure that when a valid SYN arrives shortly thereafter
+// (with the same address 4-tuple) we can still successfully establish
+// a connection.
+
+0.200 < S 0:0(0) win 65535 <mss 1460,sackOK,nop,nop,nop,wscale 7>
+0.200 > S. 0:0(0) ack 1 <...>
+
+0.300 < . 1:1(0) ack 1 win 65535
+0.300 accept(3, ..., ...) = 4

--- a/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-no-tcp-flags.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-no-tcp-flags.pkt
@@ -1,5 +1,9 @@
-// Test behavior when a listener gets an incoming packet that has
-// no TCP flags set.
+// Test behavior when a listener gets an incoming packet from
+// new sender on a non-established connection that
+// doesn't have any of the TCP flags set.
+// Listener should not send any response.
+// Checking if we can establish a connection with the
+// system after a connection reset.
 
 0.000 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
 0.000 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0


### PR DESCRIPTION
Testing whether a connection can be re-established when injecting a packet with no TCP flag set.