### PR TITLE
Test for behavior when sending a packet with both SYN and RST bits set

### DIFF
--- a/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-syn-rst.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-syn-rst.pkt
@@ -1,5 +1,8 @@
-// Test behavior when a listener gets an incoming packet that has
-// the SYN and RST bits set.
+// Test behavior when a listener gets an incoming packet from new
+// sender on a non-established session that has the SYN and RST bits set.
+// The listener should send a RESET.
+// Checking if we can establish a connection with the client
+// after a connection reset.
 
 0.000 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
 0.000 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0

--- a/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-syn-rst.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/listen/listen-incoming-syn-rst.pkt
@@ -1,0 +1,22 @@
+// Test behavior when a listener gets an incoming packet that has
+// the SYN and RST bits set.
+
+0.000 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+0.000 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+0.000 bind(3, ..., ...) = 0
+0.000 listen(3, 1) = 0
+
+0.100 < SR 0:0(0) win 65535 <mss 1460,sackOK,nop,nop,nop,wscale 7>
+
+// The TCP stack should not respond to incoming RSTs, or else
+// we could get infinite RST ping-pong storms.
+
+// Now make sure that when a valid SYN arrives shortly thereafter
+// (with the same address 4-tuple) we can still successfully establish
+// a connection.
+
+0.200 < S 0:0(0) win 65535 <mss 1460,sackOK,nop,nop,nop,wscale 7>
+0.200 > S. 0:0(0) ack 1 <...>
+
+0.300 < . 1:1(0) ack 1 win 65535
+0.300 accept(3, ..., ...) = 4


### PR DESCRIPTION
Testing whether a connection can be re-established when injecting a packet with both **SYN** and **RST** bit set.