### PR TITLE
Test for checking if FIN is generated after connection close

### DIFF
--- a/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
@@ -1,0 +1,39 @@
+// Test for checking whether a FIN is generated when
+// we close the connection after read()'ing what the
+// client sent. This behavior conforms to RFC 793.
+
+0.000 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
+0.000 setsockopt(3, SOL_SOCKET, SO_REUSEADDR, [1], 4) = 0
+0.000 bind(3, ..., ...) = 0
+0.000 listen(3, 1) = 0
+
+0.100 < S 0:0(0) win 65535 <mss 1460,sackOK,nop,nop,nop,wscale 7>
+0.100 > S. 0:0(0) ack 1 <...>
+0.200 < . 1:1(0) ack 1 win 65535
+0.200 accept(3, ..., ...) = 4
+
+// We receive first segment
+0.210 < P. 1:1001(1000) ack 1 win 65535
+0.350 > . 1:1(0) ack 1001 win 1026
+
+// Our application writes 1000 bytes
+0.400 write(4, ..., 1000) = 1000
+0.400 > P. 1:1001(1000) ack 1001
+
+0.410 < . 1001:1001(0) ack 1001 win 65535
+
+0.420 read(4, ..., 1000) = 1000
+
+// Client closes connection
+0.450 < F. 1001:1001(0) ack 1001 win 65535
+
+// TODO: ack or delayed ack ?
+0.460 > . 1001:1001(0) ack 1002 win 1026
+
+// We close the connection with a delay, in case there
+// is still data left to send
+0.470 close(4) = 0
+0.480 > F. 1001:1001(0) ack 1002 win 1026
+
+// The success of the tests depends on the correctness
+// of the inbound sniffed packet on line 36.

--- a/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
@@ -34,9 +34,9 @@
 0.460 > . 1001:1001(0) ack 1002 win 1026
 
 // We close the connection with a delay, in case there
-// is still data left to send
+// is still data left to read
 0.470 close(4) = 0
-0.480 > F. 1001:1001(0) ack 1002 win 1026
+0.470 > F. 1001:1001(0) ack 1002 win 1026
 
 // The success of the tests depends on the correctness
-// of the inbound sniffed packet on line 36.
+// of the outbound sniffed packet on line 39.

--- a/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
+++ b/gtests/net/packetdrill/tests/bsd/tcp/close/close-read-data-fin.pkt
@@ -14,12 +14,15 @@
 
 // We receive first segment
 0.210 < P. 1:1001(1000) ack 1 win 65535
+
+// We send one ACK
 0.350 > . 1:1(0) ack 1001 win 1026
 
 // Our application writes 1000 bytes
 0.400 write(4, ..., 1000) = 1000
 0.400 > P. 1:1001(1000) ack 1001
 
+// Client sends one ACK
 0.410 < . 1001:1001(0) ack 1001 win 65535
 
 0.420 read(4, ..., 1000) = 1000


### PR DESCRIPTION
Test for checking whether **FIN** is generated when we close the connection after **read()**ing what the client sent. This behavior conforms to **RFC 793**. 