### PR TITLE
validate return value and errno of FreeBSD sendfile

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -4817,7 +4817,6 @@ static int syscall_sendfile(struct state *state, struct syscall_spec *syscall,
 		goto error_out;
 	}
 
-	status = STATUS_OK;
 error_out:
 	sf_hdtr_free(sf_hdtr);
 	return status;


### PR DESCRIPTION
Simple change to allow full validation of sendfile return value and errno.

Edit: this was originally a more complex patch with special processing for EAGAIN.