### PR TITLE
Fix length issue of sctp_primary_addr.pkt on Linux

### DIFF
--- a/gtests/net/packetdrill/tests/linux/sctp/api_tests/getsockopt/sctp_primary_addr.pkt
+++ b/gtests/net/packetdrill/tests/linux/sctp/api_tests/getsockopt/sctp_primary_addr.pkt
@@ -13,19 +13,19 @@
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, {ssp_assoc_id=...,
 						   ssp_addr={sa_family=AF_INET,
 							     sin_port=htons(8080),
-							     sin_addr=inet_addr("192.0.2.1")}}, 136) = 0
+							     sin_addr=inet_addr("192.0.2.1")}}, 132) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, {ssp_assoc_id=...,
 						   ssp_addr={sa_family=AF_INET,
 						   sin_port=htons(8080),
-						   sin_addr=inet_addr("192.0.2.1")}}, [136]) = 0
+						   sin_addr=inet_addr("192.0.2.1")}}, [132]) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, {ssp_assoc_id=...,
-						   ssp_addr=...}, [136]) = 0
+						   ssp_addr=...}, [132]) = 0
 
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, {ssp_addr={sa_family=AF_INET,
 							     sin_port=htons(8080),
-							     sin_addr=inet_addr("192.0.2.1")}}, 136) = 0
+							     sin_addr=inet_addr("192.0.2.1")}}, 132) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PRIMARY_ADDR, {ssp_addr={sa_family=AF_INET,
 						   sin_port=htons(8080),
-						   sin_addr=inet_addr("192.0.2.1")}}, [136]) = 0
+						   sin_addr=inet_addr("192.0.2.1")}}, [132]) = 0
 
 +0 close(3) = 0


### PR DESCRIPTION
Before fix:
   sctp_primary_addr.pkt:13: runtime error in setsockopt call: Expected result 0 but got -1 with errno 22 (Invalid argument)

After fix:
   test passed both on Linux x86_64 and ppc64le

Signed-off-by: Jianwen Ji <jijianwen@gmail.com>