### PR TITLE
Fix some errors when running sctp_socket_options.pkt

### DIFF
--- a/gtests/net/packetdrill/tests/linux/sctp/sctp_socket_options.pkt
+++ b/gtests/net/packetdrill/tests/linux/sctp/sctp_socket_options.pkt
@@ -38,14 +38,14 @@
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_DELAYED_SACK, {sack_delay=200, sack_freq=2}, 13) = -1 EINVAL (Invalid argument)
 +0 setsockopt(3, IPPROTO_SCTP, SCTP_DELAYED_SACK, {sack_delay=200, sack_freq=2}, 11) = -1 EINVAL (Invalid argument)
 
-+0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_value=1}, 8) = 0
-+0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_value=0}, 8) = 0
-+0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_value=1024}, 8) = 0
-+0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_value=1}, 9) = -1 EINVAL (Invalid argument)
-+0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_value=1}, 7) = -1 EINVAL (Invalid argument)
++0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_id=0, assoc_value=1}, 8) = 0
++0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_id=0, assoc_value=0}, 8) = 0
++0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_id=0, assoc_value=1024}, 8) = 0
++0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_id=0, assoc_value=1}, 9) = -1 EINVAL (Invalid argument)
++0 setsockopt(3, IPPROTO_SCTP, SCTP_MAX_BURST, {assoc_id=0, assoc_value=1}, 7) = -1 EINVAL (Invalid argument)
 
-+0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address=..., spp_hbinterval=30000, spp_pathmaxrxt=100, spp_pathmtu=1468, spp_flags=0, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
+//+0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address=..., spp_hbinterval=30000, spp_pathmaxrxt=100, spp_pathmtu=1468, spp_flags=0, spp_ipv6_flowlabel=0, spp_dscp=0}, [152]) = 0
 +0 getsockopt(3, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, {spp_address={sa_family=AF_INET, sin_port=htons(0), sin_addr=inet_addr("0.0.0.0")},
-spp_hbinterval=30000, spp_pathmaxrxt=6, spp_pathmtu=..., spp_flags=..., spp_ipv6_flowlabel=..., spp_dscp=...}, [152]) = 0
+spp_hbinterval=30000, spp_pathmaxrxt=5, spp_pathmtu=..., spp_flags=..., spp_ipv6_flowlabel=..., spp_dscp=...}, [152]) = 0
 
 +0 close(3) = 0


### PR DESCRIPTION
1) sctp_socket_options.pkt:41: runtime error in setsockopt call:
   Expected result 0 but got -1 with errno 22 (Invalid argument)

   add 'assoc_id=0' for getsockopt(SCTP_MAX_BURST).

2) sctp_socket_options.pkt:47: runtime error in getsockopt call:
   can't determine spp_address

   comment out this item which should not be run

3) sctp_socket_options.pkt:48: runtime error in getsockopt call:
   sctp_paddrparams.spp_pathmaxrxt: expected: 6 actual: 5

   change spp_pathmaxrxt to be 5 since the default value of
   path_max_retrans is 5 on Linux.

Signed-off-by: Jianwen Ji <jijianwen@gmail.com>