### PR TITLE
Improve AccECN packet decoder

### DIFF
--- a/gtests/net/packetdrill/packet_to_string.c
+++ b/gtests/net/packetdrill/packet_to_string.c
@@ -199,8 +199,6 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet, int i,
 		fputc('R', s);
 	if (packet->tcp->psh)
 		fputc('P', s);
-	if (packet->tcp->ack)
-		fputc('.', s);
 	if (packet->tcp->urg)
 		fputc('U', s);
 	if (packet->flags & FLAG_PARSE_ACE) {
@@ -219,6 +217,8 @@ static int tcp_packet_to_string(FILE *s, struct packet *packet, int i,
 		if (packet->tcp->ae)
 			fputc('A', s);   /* *A*ccurate ECN */
 	}
+	if (packet->tcp->ack)
+		fputc('.', s);
 
 	fprintf(s, " %u:%u(%u)",
 		ntohl(packet->tcp->seq),

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -3022,6 +3022,10 @@ out:
 	add_packet_dump(error, "script", script_packet, script_usecs,
 			DUMP_SHORT);
 	if (actual_packet != NULL) {
+		if (script_packet->flags & FLAG_PARSE_ACE) {
+			/* set numeric ACE count flag on actual packet as well */
+			actual_packet->flags |= FLAG_PARSE_ACE;
+		}
 		add_packet_dump(error, "actual", actual_packet,
 				actual_usecs, DUMP_SHORT);
 		packet_free(actual_packet);


### PR DESCRIPTION
Move the ACK "." as the last character in the tcp packet dump, and if the script packet uses ACE notation, do the same when decoding a sniffed packet.