### PR TITLE
use sched_yield() instead of pthread_yield()

### DIFF
--- a/gtests/net/packetdrill/run_system_call.c
+++ b/gtests/net/packetdrill/run_system_call.c
@@ -7113,13 +7113,11 @@ static int await_idle_thread(struct state *state)
 #if !defined(__SunOS_5_11)
 static int yield(void)
 {
-#if defined(linux)
-	return pthread_yield();
+#if defined(linux) || defined(__NetBSD__)
+	return sched_yield();
 #elif defined(__FreeBSD__) || defined(__OpenBSD__)
 	pthread_yield();
 	return 0;
-#elif defined(__NetBSD__)
-	return sched_yield();
 #elif defined(__APPLE__)
 	pthread_yield_np();
 	return 0;


### PR DESCRIPTION
Starting with Ubuntu 22.04 (Linux 5.15) pthread_yield() was removed. This fix replaces it with sched_yield()