### PR TITLE
Rework parser for ip fields

### DIFF
--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -2856,138 +2856,125 @@ hlim
 
 ip_info
 : tos_spec	{
-	$$.tos.check = $1.check;
-	$$.tos.value = $1.value;
-	$$.flow_label = 0;
-	$$.ttl = 0;
+	$$ = ip_info_new();
+	$$.tos = $1;
 }
 | ttl {
-	$$.tos.check = TOS_CHECK_NONE;
-	$$.tos.value = 0;
-	$$.flow_label = 0;
+	$$ = ip_info_new();
 	$$.ttl = $1;
 }
 | tos_spec ',' ttl {
-	$$.tos.check = $1.check;
-	$$.tos.value = $1.value;
-	$$.flow_label = 0;
+	$$ = ip_info_new();
+	$$.tos = $1;
 	$$.ttl = $3;
 }
 | flow_label	{
-	$$.tos.check = TOS_CHECK_NONE;
-	$$.tos.value = 0;
+	$$ = ip_info_new();
 	$$.flow_label = $1;
-	$$.ttl = 0;
 }
 | hlim {
-	$$.tos.check = TOS_CHECK_NONE;
-	$$.tos.value = 0;
-	$$.flow_label = 0;
+	$$ = ip_info_new();
 	$$.ttl = $1;
 }
 | tos_spec ',' flow_label {
-	$$.tos.check = $1.check;
-	$$.tos.value = $1.value;
+	$$ = ip_info_new();
+	$$.tos = $1;
 	$$.flow_label = $3;
-	$$.ttl = 0;
 }
 | tos_spec ',' hlim {
-	$$.tos.check = $1.check;
-	$$.tos.value = $1.value;
-	$$.flow_label = 0;
+	$$ = ip_info_new();
+	$$.tos = $1;
 	$$.ttl = $3;
 }
 | flow_label ',' hlim {
-	$$.tos.check = TOS_CHECK_NONE;
-	$$.tos.value = 0;
+	$$ = ip_info_new();
 	$$.flow_label = $1;
 	$$.ttl = $3;
 }
 | tos_spec ',' flow_label ',' hlim {
-	$$.tos.check = $1.check;
-	$$.tos.value = $1.value;
+	$$ = ip_info_new();
+	$$.tos = $1;
 	$$.flow_label = $3;
 	$$.ttl = $5;
 }
 | dscp	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
-	$$.ttl = 0;
 }
 | dscp ',' ttl	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
 	$$.ttl = $3;
 }
 | dscp ',' hlim	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
 	$$.ttl = $3;
 }
 | dscp ',' flow_label	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
 	$$.flow_label = $3;
-	$$.ttl = 0;
 }
 | dscp ',' flow_label ',' hlim	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
 	$$.flow_label = $3;
 	$$.ttl = $5;
 }
 | dscp ',' ECN ip_ecn	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_TOS;
 	$$.tos.value = $1 << 2 | $4;
-	$$.flow_label = 0;
-	$$.ttl = 0;
 }
 | dscp ',' ECN ip_ecn ',' ttl	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_TOS;
 	$$.tos.value = $1 << 2 | $4;
-	$$.flow_label = 0;
 	$$.ttl = $6;
 }
 | dscp ',' ECN ip_ecn ',' hlim	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_TOS;
 	$$.tos.value = $1 << 2 | $4;
-	$$.flow_label = 0;
 	$$.ttl = $6;
 }
 | dscp ',' ECN ip_ecn ',' flow_label	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_TOS;
 	$$.tos.value = $1 << 2 | $4;
 	$$.flow_label = $6;
-	$$.ttl = 0;
 }
 | dscp ',' ECN ECT01	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
-	$$.ttl = 0;
 }
 | dscp ',' ECN ECT01 ',' ttl	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
 	$$.ttl = $6;
 }
 | dscp ',' ECN ECT01 ',' hlim	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = 0;
 	$$.ttl = $6;
 }
 | dscp ',' ECN ECT01 ',' flow_label	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
 	$$.tos.value = $1 << 2;
 	$$.flow_label = $6;
-	$$.ttl = 0;
 }
 | dscp ',' ECN ECT01 ',' flow_label ',' hlim	{
+	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
 	$$.tos.value = $1 << 2;
 	$$.flow_label = $6;
@@ -2997,10 +2984,7 @@ ip_info
 
 opt_ip_info
 :			{
-	$$.tos.check = TOS_CHECK_NONE;
-	$$.tos.value = 0;
-	$$.flow_label = 0;
-	$$.ttl = 0;
+	$$ = ip_info_new();
 }
 | '(' ip_info ')'	{ $$ = $2; }
 | '[' ip_info ']'	{ $$ = $2; }

--- a/gtests/net/packetdrill/parser.y
+++ b/gtests/net/packetdrill/parser.y
@@ -493,7 +493,6 @@ static struct tcp_option *new_tcp_exp_fast_open_option(const char *cookie_string
 	s64 time_usecs;
 	enum direction_t direction;
 	u8 ip_ecn;
-	struct tos_spec tos_spec;
 	struct ip_info ip_info;
 	struct mpls_stack *mpls_stack;
 	struct mpls mpls_stack_entry;
@@ -666,7 +665,6 @@ static struct tcp_option *new_tcp_exp_fast_open_option(const char *cookie_string
 %type <ignore_integer> ignore_integer
 %type <direction> direction
 %type <ip_info> ip_info opt_ip_info
-%type <tos_spec> tos_spec
 %type <ip_ecn> ip_ecn
 %type <option> option options opt_options
 %type <event> event events event_time action
@@ -2752,39 +2750,6 @@ dscp
 | DSCP LE { $$ = DSCP_LE; }
 ;
 
-tos_spec
-: ip_ecn		{ $$.check = TOS_CHECK_ECN; $$.value = $1; }
-| ECT01			{ $$.check = TOS_CHECK_ECN_ECT01; $$.value = 0; }
-| TOS HEX_INTEGER	{
-	s64 tos = $2;
-
-	if (!is_valid_u8(tos)) {
-		semantic_error("tos out of range for 8 bits");
-	}
-
-	$$.check = TOS_CHECK_TOS;
-	$$.value = tos;
-}
-| CLASS HEX_INTEGER	{
-	s64 class = $2;
-
-	if (!is_valid_u8(class)) {
-		semantic_error("class out of range for 8 bits");
-	}
-
-	$$.check = TOS_CHECK_TOS;
-	$$.value = class;
-}
-| ECN ip_ecn	{
-	$$.check = TOS_CHECK_ECN;
-	$$.value = $2;
-}
-| ECN ECT01	{
-	$$.check = TOS_CHECK_ECN_ECT01;
-	$$.value = 0;
-}
-;
-
 ip_ecn
 : NO_ECN	{ $$ = IP_ECN_NONE; }
 | ECT0		{ $$ = IP_ECN_ECT0; }
@@ -2855,130 +2820,213 @@ hlim
 }
 
 ip_info
-: tos_spec	{
-	$$ = ip_info_new();
-	$$.tos = $1;
-}
-| ttl {
+: ttl {
 	$$ = ip_info_new();
 	$$.ttl = $1;
 }
-| tos_spec ',' ttl {
-	$$ = ip_info_new();
-	$$.tos = $1;
+| ip_info ',' ttl {
+	$$ = $1;
 	$$.ttl = $3;
-}
-| flow_label	{
-	$$ = ip_info_new();
-	$$.flow_label = $1;
 }
 | hlim {
 	$$ = ip_info_new();
 	$$.ttl = $1;
 }
-| tos_spec ',' flow_label {
-	$$ = ip_info_new();
-	$$.tos = $1;
-	$$.flow_label = $3;
-}
-| tos_spec ',' hlim {
-	$$ = ip_info_new();
-	$$.tos = $1;
+| ip_info ',' hlim {
+	$$ = $1;
 	$$.ttl = $3;
 }
-| flow_label ',' hlim {
+| flow_label {
 	$$ = ip_info_new();
 	$$.flow_label = $1;
-	$$.ttl = $3;
 }
-| tos_spec ',' flow_label ',' hlim {
-	$$ = ip_info_new();
-	$$.tos = $1;
-	$$.flow_label = $3;
-	$$.ttl = $5;
-}
-| dscp	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP;
-	$$.tos.value = $1 << 2;
-}
-| dscp ',' ttl	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP;
-	$$.tos.value = $1 << 2;
-	$$.ttl = $3;
-}
-| dscp ',' hlim	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP;
-	$$.tos.value = $1 << 2;
-	$$.ttl = $3;
-}
-| dscp ',' flow_label	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP;
-	$$.tos.value = $1 << 2;
+| ip_info ',' flow_label {
+	$$ = $1;
 	$$.flow_label = $3;
 }
-| dscp ',' flow_label ',' hlim	{
+/* different possibilities to set the tos/class field */
+// set entire field
+| TOS HEX_INTEGER {
+	$$ = ip_info_new();
+	s64 tos = $2;
+
+	if (!is_valid_u8(tos)) {
+		semantic_error("tos out of range for 8 bits");
+	}
+
+	$$.tos.check = TOS_CHECK_TOS;
+	$$.tos.value = tos;
+}
+| ip_info ',' TOS HEX_INTEGER {
+	$$ = $1;
+	s64 tos = $4;
+
+	if ($1.tos.check != TOS_CHECK_NONE) {
+		semantic_error("tos already set");
+	}
+
+	if (!is_valid_u8(tos)) {
+		semantic_error("tos out of range for 8 bits");
+	}
+
+	$$.tos.check = TOS_CHECK_TOS;
+	$$.tos.value = tos;
+}
+| CLASS HEX_INTEGER {
+	$$ = ip_info_new();
+	s64 class = $2;
+
+	if (!is_valid_u8(class)) {
+		semantic_error("class out of range for 8 bits");
+	}
+
+	$$.tos.check = TOS_CHECK_TOS;
+	$$.tos.value = class;
+}
+| ip_info ',' CLASS HEX_INTEGER {
+	$$ = $1;
+	s64 class = $4;
+
+	if ($1.tos.check != TOS_CHECK_NONE) {
+		semantic_error("class already set");
+	}
+
+	if (!is_valid_u8(class)) {
+		semantic_error("class out of range for 8 bits");
+	}
+
+	$$.tos.check = TOS_CHECK_TOS;
+	$$.tos.value = class;
+}
+// set only dscp part
+| dscp {
 	$$ = ip_info_new();
 	$$.tos.check = TOS_CHECK_DSCP;
 	$$.tos.value = $1 << 2;
-	$$.flow_label = $3;
-	$$.ttl = $5;
 }
-| dscp ',' ECN ip_ecn	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_TOS;
-	$$.tos.value = $1 << 2 | $4;
+| ip_info ',' dscp {
+	$$ = $1;
+
+	switch ($$.tos.check) {
+	case TOS_CHECK_NONE:
+		$$.tos.check = TOS_CHECK_DSCP;
+		$$.tos.value = $3 << 2;
+		break;
+	case TOS_CHECK_ECN:
+		$$.tos.check = TOS_CHECK_TOS;
+		$$.tos.value = $3 << 2 | ($$.tos.value & IP_ECN_MASK);
+		break;
+	case TOS_CHECK_ECN_ECT01:
+		$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
+		$$.tos.value = $3 << 2;
+		break;
+	case TOS_CHECK_TOS:
+	case TOS_CHECK_DSCP:
+	case TOS_CHECK_DSCP_ECN_ECT01:
+		semantic_error("can't set dscp, tos already set");
+		break;
+	}
 }
-| dscp ',' ECN ip_ecn ',' ttl	{
+// set ecn part
+| ECN ip_ecn {
 	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_TOS;
-	$$.tos.value = $1 << 2 | $4;
-	$$.ttl = $6;
+	$$.tos.check = TOS_CHECK_ECN;
+	$$.tos.value = $2;
 }
-| dscp ',' ECN ip_ecn ',' hlim	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_TOS;
-	$$.tos.value = $1 << 2 | $4;
-	$$.ttl = $6;
+| ip_info ',' ECN ip_ecn {
+	$$ = $1;
+
+	switch ($$.tos.check) {
+	case TOS_CHECK_NONE:
+		$$.tos.check = TOS_CHECK_ECN;
+		$$.tos.value = $4;
+		break;
+	case TOS_CHECK_DSCP:
+		$$.tos.check = TOS_CHECK_TOS;
+		$$.tos.value = ($$.tos.value & !IP_ECN_MASK) | $4;
+		break;
+	case TOS_CHECK_ECN:
+	case TOS_CHECK_ECN_ECT01:
+	case TOS_CHECK_TOS:
+	case TOS_CHECK_DSCP_ECN_ECT01:
+		semantic_error("can't set ecn, tos already set");
+		break;
+	}
 }
-| dscp ',' ECN ip_ecn ',' flow_label	{
+| ip_ecn {
 	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_TOS;
-	$$.tos.value = $1 << 2 | $4;
-	$$.flow_label = $6;
+	$$.tos.check = TOS_CHECK_ECN;
+	$$.tos.value = $1;
 }
-| dscp ',' ECN ECT01	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
-	$$.tos.value = $1 << 2;
+| ip_info ',' ip_ecn {
+	$$ = $1;
+
+	switch ($$.tos.check) {
+	case TOS_CHECK_NONE:
+		$$.tos.check = TOS_CHECK_ECN;
+		$$.tos.value = $3;
+		break;
+	case TOS_CHECK_DSCP:
+		$$.tos.check = TOS_CHECK_TOS;
+		$$.tos.value = ($$.tos.value & !IP_ECN_MASK) | $3;
+		break;
+	case TOS_CHECK_ECN:
+	case TOS_CHECK_ECN_ECT01:
+	case TOS_CHECK_TOS:
+	case TOS_CHECK_DSCP_ECN_ECT01:
+		semantic_error("can't set ecn, tos already set");
+		break;
+	}
 }
-| dscp ',' ECN ECT01 ',' ttl	{
+| ECN ECT01 {
 	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
-	$$.tos.value = $1 << 2;
-	$$.ttl = $6;
+	$$.tos.check = TOS_CHECK_ECN_ECT01;
+	$$.tos.value = 0;
 }
-| dscp ',' ECN ECT01 ',' hlim	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
-	$$.tos.value = $1 << 2;
-	$$.ttl = $6;
+| ip_info ',' ECN ECT01 {
+	$$ = $1;
+
+	switch ($$.tos.check) {
+	case TOS_CHECK_NONE:
+		$$.tos.check = TOS_CHECK_ECN_ECT01;
+		$$.tos.value = 0;
+		break;
+	case TOS_CHECK_DSCP:
+		$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
+		$$.tos.value = 0;
+		break;
+	case TOS_CHECK_ECN:
+	case TOS_CHECK_ECN_ECT01:
+	case TOS_CHECK_TOS:
+	case TOS_CHECK_DSCP_ECN_ECT01:
+		semantic_error("can't set ECT01, tos already set");
+		break;
+	}
 }
-| dscp ',' ECN ECT01 ',' flow_label	{
+| ECT01 {
 	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
-	$$.tos.value = $1 << 2;
-	$$.flow_label = $6;
+	$$.tos.check = TOS_CHECK_ECN_ECT01;
+	$$.tos.value = 0;
 }
-| dscp ',' ECN ECT01 ',' flow_label ',' hlim	{
-	$$ = ip_info_new();
-	$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
-	$$.tos.value = $1 << 2;
-	$$.flow_label = $6;
-	$$.ttl = $8;
+| ip_info ',' ECT01 {
+	$$ = $1;
+
+	switch ($$.tos.check) {
+	case TOS_CHECK_NONE:
+		$$.tos.check = TOS_CHECK_ECN_ECT01;
+		$$.tos.value = 0;
+		break;
+	case TOS_CHECK_DSCP:
+		$$.tos.check = TOS_CHECK_DSCP_ECN_ECT01;
+		$$.tos.value = 0;
+		break;
+	case TOS_CHECK_ECN:
+	case TOS_CHECK_ECN_ECT01:
+	case TOS_CHECK_TOS:
+	case TOS_CHECK_DSCP_ECN_ECT01:
+		semantic_error("can't set ECT01, tos already set");
+		break;
+	}
 }
 ;
 

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -3657,7 +3657,7 @@ int reset_connection(struct state *state, struct socket *socket)
 	u32 seq = 0, ack_seq = 0;
 	struct packet *packet = NULL;
 	struct tuple live_inbound;
-	const struct ip_info ip_info = {{TOS_CHECK_NONE, 0}, 0};
+	const struct ip_info ip_info = ip_info_new();
 	int result = STATUS_OK;
 	u16 udp_src_port;
 	u16 udp_dst_port;
@@ -3729,7 +3729,7 @@ int abort_association(struct state *state, struct socket *socket)
 	struct sctp_chunk_list *chunk_list;
 	struct sctp_cause_list *cause_list;
 	struct tuple live_inbound;
-	const struct ip_info ip_info = {{TOS_CHECK_NONE, 0}, 0};
+	const struct ip_info ip_info = ip_info_new();
 	int result;
 	s64 flgs;
 	u16 udp_src_port;

--- a/gtests/net/packetdrill/types.h
+++ b/gtests/net/packetdrill/types.h
@@ -151,6 +151,17 @@ struct ip_info {
 	u8 ttl;
 };
 
+static inline struct ip_info ip_info_new() {
+	struct ip_info info;
+
+	info.tos.check = TOS_CHECK_NONE;
+	info.tos.value = 0;
+	info.flow_label = 0;
+	info.ttl = 0;
+
+	return info;
+}
+
 /* Type to handle <integer>! for specifying absolute vs adjusted values.
  * The <integer>! means absolute integer. Just a plain <integer> is relative.
  */


### PR DESCRIPTION
A rework on the parsing of IP fields.

Pro:
- Arbitrary order of definition in scripts.
- Easy to add additional fields in the future.

Con:
- Fields can be defined multiple times in scripts (except ttl/class, those are checked on compatibility).