### PR TITLE
remote_udp: upstream code adopted

### DIFF
--- a/gtests/net/packetdrill/packet.h
+++ b/gtests/net/packetdrill/packet.h
@@ -370,14 +370,14 @@ static inline u8 *packet_echoed_ip_header(struct packet *packet)
 }
 
 /* Return the location of the IPv4 header echoed by an ICMP message, or NULL. */
-static inline struct ipv4 *packet_echoed_ipv4_header(struct packet *packet)
+static inline struct ipv4 *packet_echoed_ipv4_header(const struct packet *packet)
 {
 	return (struct ipv4 *)((packet->icmpv4 != NULL) ?
 			       (packet->icmpv4 + 1) : NULL);
 }
 
 /* Return the location of the IPv6 header echoed by an ICMP message, or NULL. */
-static inline struct ipv6 *packet_echoed_ipv6_header(struct packet *packet)
+static inline struct ipv6 *packet_echoed_ipv6_header(const struct packet *packet)
 {
 	return (struct ipv6 *)((packet->icmpv6 != NULL) ?
 			       (packet->icmpv6 + 1) : NULL);
@@ -397,7 +397,7 @@ static inline int packet_echoed_ip_header_len(struct packet *packet)
 }
 
 /* Return the layer4 protocol of the packet echoed inside an ICMP packet. */
-static inline int packet_echoed_ip_protocol(struct packet *packet)
+static inline int packet_echoed_ip_protocol(const struct packet *packet)
 {
 	if (packet->icmpv4 != NULL)
 		return packet_echoed_ipv4_header(packet)->protocol;

--- a/gtests/net/packetdrill/run_packet.c
+++ b/gtests/net/packetdrill/run_packet.c
@@ -451,6 +451,75 @@ static struct socket *handle_connect_for_script_packet(
 	return socket;
 }
 
+static struct socket *create_socket_for_nontcp_script_packet(
+	struct state *state, const struct packet *packet,
+	enum direction_t direction)
+{
+	struct config *config = state->config;
+	struct socket *socket = NULL;
+	struct tuple tuple;
+
+	DEBUGP("create_socket_for_nontcp_script_packet: direction: %u "
+	       "socket_under_test: %p is_wire_server: %d\n",
+	       direction, state->socket_under_test, config->is_wire_server);
+	/* On wire servers we don't see the system calls, so we won't have any
+	 * socket_under_test yet when we see the first packet for a socket.
+	 */
+	if (!(state->socket_under_test == NULL &&
+	      config->is_wire_server))
+		return NULL;
+
+	/* On a wire server and we have no socket info yet. Create a socket for
+	 * this packet. Any further packets in the test script are mapped here.
+	 */
+	DEBUGP("create_socket_for_nontcp_script_packet: creating socket\n");
+	socket = socket_new(state);
+	state->socket_under_test = socket;
+	/* Set state so that find_connect_for_live_packet() will know that
+	 * outbound packets can match this socket.
+	 */
+	socket->state = SOCKET_ACTIVE_CONNECTING;
+	socket->address_family = packet_address_family(packet);
+
+	/* If this is an ICMP packet with an echoed IP/transport header inside,
+	 * then look at the layer 4 protocol indicated in the echoed IP
+	 * header.
+	 */
+	if (((packet->icmpv4 != NULL) || (packet->icmpv6 != NULL)) &&
+	    packet->echoed_header)
+		socket->protocol = packet_echoed_ip_protocol(packet);
+	else
+		socket->protocol = packet_ip_protocol(packet, config->udp_encaps);
+
+	get_packet_tuple(packet, &tuple);
+
+	socket->live.fd	 = -1;
+	socket->script.fd	 = -1;
+
+	/* Fill in the new info about this connection. */
+	if (direction == DIRECTION_OUTBOUND) {
+		DEBUGP("setting fields for DIRECTION_OUTBOUND\n");
+		socket->script.remote		= tuple.dst;
+		socket->script.local		= tuple.src;
+
+		socket->live.remote.ip   = config->live_remote_ip;
+		socket->live.remote.port = htons(config->live_connect_port);
+	} else if (direction == DIRECTION_INBOUND) {
+		DEBUGP("setting fields for DIRECTION_INBOUND\n");
+		socket->script.remote		= tuple.src;
+		socket->script.local		= tuple.dst;
+
+		u16 remote_port = next_ephemeral_port(state);
+		socket->live.remote.ip		= config->live_remote_ip;
+		socket->live.remote.port	= htons(remote_port);
+		socket->live.local.ip		= config->live_local_ip;
+		socket->live.local.port		= htons(config->live_bind_port);
+	} else {
+		assert(!"bad direction");  /* internal bug */
+	}
+	return socket;
+}
+
 /* Look for a connecting socket that would emit this outgoing live packet. */
 static struct socket *find_connect_for_live_packet(
 	struct state *state, struct packet *packet,
@@ -3193,6 +3262,11 @@ static int find_or_create_socket_for_script_packet(
 		/* Is this an outbound packet matching a connecting socket? */
 		*socket = handle_connect_for_script_packet(state,
 							   packet, direction);
+		if (*socket != NULL)
+			return STATUS_OK;
+	} else {
+		*socket = create_socket_for_nontcp_script_packet(state, packet,
+								 direction);
 		if (*socket != NULL)
 			return STATUS_OK;
 	}


### PR DESCRIPTION
add code from packetdrill upstream that creates a socket when wire_server receives the first UDP packet.