### PR TITLE
Upstream FreeBSD port’s patches

### DIFF
--- a/gtests/net/packetdrill/symbols_freebsd.c
+++ b/gtests/net/packetdrill/symbols_freebsd.c
@@ -412,7 +412,9 @@ struct int_symbol platform_symbols_table[] = {
 	{ TCP_NOOPT,                        "TCP_NOOPT"                       },
 	{ TCP_MD5SIG,                       "TCP_MD5SIG"                      },
 	{ TCP_INFO,                         "TCP_INFO"                        },
+#if defined(TCP_STATS)
 	{ TCP_STATS,                        "TCP_STATS"                       },
+#endif
 #if defined(TCP_LOG)
 	{ TCP_LOG,                          "TCP_LOG"                         },
 #endif

--- a/gtests/net/packetdrill/tcp_options.h
+++ b/gtests/net/packetdrill/tcp_options.h
@@ -167,7 +167,7 @@ struct tcp_option {
 		struct {
 			u8 data[MAX_TCP_OPTION_DATA_BYTES];
 		} generic;
-	};
+	} __packed;
 	u32 flags;  /* meta information, not going on the wire */
 } __packed;
 


### PR DESCRIPTION
- make a symbol new in FreeBSD 13 optional
- mark a union as packed that will require unaligned access

Author: Robert Clausecker <fuz@FreeBSD.org>